### PR TITLE
Experiment persistence, arggo-cli, and interactive parsing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9, 3.10]
 
 
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
 
 
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,8 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ cython_debug/
 .idea/
 logs/
 my_logs/
+temp/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,4 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
+        additional_dependencies: ["click<8.1.0"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Arggo is a Python toolkit for reproducible experiment management, inspired by Hydra and HuggingFace's `HfArgumentParser`. Given a `@dataclass` of arguments, Arggo auto-generates a CLI parser, injects the parsed arguments into a decorated main function, isolates each run in its own timestamped working directory, and persists the run's parameters to JSON for later reproduction.
+
+## Commands
+
+Install dependencies:
+```shell
+pip install -r requirements.txt -r requirements-dev.txt
+```
+
+Run all tests (with coverage):
+```shell
+python -m pytest --cov=arggo
+```
+
+Run a single test file / test:
+```shell
+python -m pytest tests/test_arggo.py
+python -m pytest tests/test_arggo.py::TestSimpleAnnotation::test_function_no_arguments
+```
+
+Format code (pre-commit uses `black`):
+```shell
+black .
+```
+
+Lint (as run in CI):
+```shell
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+```
+
+The `arggo-cli` entry point (defined in `setup.py`) is installed as a console script and is also runnable via `python -m arggo.cli.main`.
+
+## Architecture
+
+### Decorator-driven entry point (`arggo/core.py`)
+
+The public API (`arggo.consume`, `arggo.configure`) is a single decorator factory, `_main_annotation`, aliased two ways:
+- `arggo.consume` — the decorator itself, pre-applied with defaults (used as `@arggo.consume`).
+- `arggo.configure(...)` — call it with kwargs (`parser_argument_index`, `logging_dir`, `init_working_dir`, `plugins`) to customize behavior, then apply the result as a decorator.
+
+When the decorated function is called, it:
+1. Inspects the function's type hints to find the dataclass-typed argument (at `parser_argument_index`).
+2. Parses "meta-arguments" (`--arggo_help`, `--arggo_interactive`, `--arggo_reproduce`) which control Arggo's own behavior, separately from the user's dataclass fields.
+3. Builds (once, cached in a process-wide `GlobalStore`) a `DataClassArgumentParser` — or wraps it in an `InteractiveArgumentParser` if `--arggo_interactive` was passed — and uses it to construct a `NewExperiment` either from CLI args or from a previously reproduced parameters file.
+4. Initializes an isolated working directory (`Workdir`), redirects stdout to also write to a log file in that directory (`FileLogger`), and saves the experiment's parameters as JSON.
+5. Invokes the original function with the parsed dataclass instance spliced into the original argument list at `parser_argument_index`.
+
+Because parser/workdir state is cached in a global store keyed by process, calling a `configure()`/`consume`-decorated function multiple times (e.g. in a loop) reuses the same parsed arguments and working directory rather than reparsing — see the `greet_user` loop example in the README.
+
+### Argument parsing (`arggo/parser.py`)
+
+`DataClassArgumentParser` extends `argparse.ArgumentParser`, introspecting dataclass fields (including special handling for `bool`, `List[T]`, and `Enum` fields) to auto-generate CLI arguments. Field-level customization (help text, choices, required-ness, custom type mappers) is attached via `dataclasses.field(metadata=...)`, which `arggo.dataclass_utils.parser_field`/`mapped_field` make ergonomic. This parser also supports `parse_json_file`/`parse_dict` for non-CLI instantiation, used when reproducing a past run.
+
+### Experiments (`arggo/experiment/experiment.py`)
+
+`Experiment` is the abstract notion of a run's parameters + metadata (executable, command, script path, reproduced-from path, and plugin dumps). Two concrete implementations:
+- `NewExperiment` — a run being started now; built `from_arguments()` (parse CLI) or `from_reproduced()` (parse a saved `parameters.json`).
+- `FinishedExperiment` — a previously completed run loaded back from its `parameters.json` on disk, used by `arggo-cli experiment reproduce` to re-invoke the original script with `--arggo_reproduce <dir>`.
+
+### Working directory isolation (`arggo/environment/workdir.py`)
+
+`Workdir` wraps a pluggable `DirectoryStrategy` (default: real `os.makedirs`/`os.chdir`) and tracks original/current directories in the `GlobalStore` so state survives across the decorated calls within one process. `init_workdir` creates a `<logging_dir>/%Y-%m-%d/%H-%M-%S` directory and chdirs into it — this is what gives each run its own isolated output location (see `logs/`, `my_logs/` in the repo, which are per-run output examples and are gitignored).
+
+### Global process state (`arggo/_internal/global_store.py`)
+
+A minimal namespaced key-value store backed by a module-level dict, used wherever Arggo needs state that must persist across multiple decorated-function invocations in the same process (parser cache, workdir, logger-bound flag) without threading it through function signatures explicitly.
+
+### Plugins (`arggo/plugin.py`, `arggo/integration/`)
+
+`Plugin` is an abstract hook (`name`, `parameters_dump()`) for attaching extra metadata to a saved experiment. `CondaPlugin` (`arggo/integration/conda.py`) is the only built-in plugin, recording the active conda environment when present. Default plugins are loaded in `core.py::_load_default_plugins()`; additional plugins are passed via `arggo.configure(plugins=[...])`.
+
+### CLI (`arggo/cli/`)
+
+Built with `click`. `cli.py` holds the actual command implementations (`experiment_create`, `experiment_run`, `experiment_reproduce`); `click_hooks.py` wires them into the `arggo-cli` command group (`experiment create|reproduce|run`); `main.py` is the `python -m` entry point. `experiment create <name>` renders `arggo/templates/experiment_create.jinja` into a new starter script. `experiment reproduce <name>` recursively searches a logging directory for saved `parameters.json` files matching the experiment name and lets the user pick one to re-run.
+
+### Interactive mode (external `interactive_argparse` package)
+
+Interactive prompting is delegated to the sibling `InteractiveArgparse` library (`interactive_argparse` on PyPI/import path), not implemented in-tree. `core.py` wraps the generated `DataClassArgumentParser` in the library's `InteractiveArgumentParser` when the `--arggo_interactive` meta-argument is passed; the wrapper monkeypatches `parse_known_args` to convert argparse `Action`s into prompter-agnostic `Question`s and collect answers via a `Prompter` (terminal prompts through `PyInquirerPrompter` by default). Because the library's own prompt-or-not heuristic only looks at leftover CLI args, and arggo's `--arggo_interactive` flag would itself count as one, `core.py` explicitly passes `args=[]` through `NewExperiment.from_arguments` whenever that meta-flag is set, forcing the prompt unconditionally. `arggo/cli/cli.py`'s `experiment_reproduce` also builds a `Question`/`PyInquirerPrompter` directly (instead of a raw PyInquirer dict) to let the user pick which saved run to reproduce.
+
+## Notes for making changes
+
+- Supported Python range per `setup.py`/CI matrix is 3.6–3.8, but development is against whatever `python3`/`pytest` resolve to locally (currently 3.11) — be wary of relying on typing features unavailable in older Pythons (e.g. `from __future__ import annotations` / PEP 563 postponed evaluation is explicitly unsupported, see the `ImportError` raised in `DataClassArgumentParser._add_dataclass_arguments`).
+- `GlobalStore` state is process-global and not reset between test cases automatically; tests that touch `Workdir`/parser caching may need to account for this (see `tests/test_workdir.py`'s use of a `FakeDirectoryStrategy` and explicit `revert()` calls).

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include arggo/templates/*.jinja

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 :warning: This library is still in early development. We welcome contributors and early feedback :construction:
 ___
 
-:ship: Arggo is a Python library for managing experiment runs in a clean and elegant manner.
+:ship: Arggo is a Python toolkit for managing reproducible runs in a clean and elegant manner.
 
 Core features:
-* :bar_chart: Dataclass-powered automatic argument parsing
-* :football: No more passing `args` around. `arggo.consume` makes it easy for every function to consume argument objects!
+* :bar_chart: Automatic dataclass-powered argument parsing and injection.
+* :computer: Powerful CLI for run management and bootstrapping
 * :arrows_counterclockwise: Reproducibility - re-run previously saved :ship: Arggo runs with a single command.
 * :lock: Isolation - :ship: Arggo creates a new running directory for each run by default.
 
@@ -117,6 +117,54 @@ The `consume` and `configure()` decorators work for any function, and guarantee 
 configure parametes. Future versions will make `consume` automatically find
 the appropriate type parameter to inject the arguments object into, and consequently
 `configure()` will throw an error when used more than once.
+
+### Meta-arguments
+
+Arggo attaches meta-arguments to each script, allowing for some extra functionality.
+To view all possible meta-arguments, run your script with the `--arggo_help` flag
+```shell
+python main.py --arggo_help
+```
+
+#### Interactive Runs
+
+You can provide arguments to a program interactively by supplying the `--arggo_interactive` flag:
+```shell
+python main.py --arggo_help
+```
+
+### Command Line Interface
+
+Arggo powers a CLI for many useful actions. To view more information, run
+```shell
+arggo-cli --help
+```
+
+#### Creating a New Experiment
+
+```shell
+arggo-cli experiment create <experiment_name>
+```
+
+This command automatically creates a starter file `<experiment_name>.py`
+
+#### Reproducing an Existing Experiment
+
+To reproduce results of a previous experiment run, type
+```shell
+arggo-cli experiment reproduce <experiment_name>
+```
+
+This looks for any experiments in the `logs/` folder, and allows you to interactively choose which one to reproduce.
+
+## Development
+
+### Running tests
+
+To run all tests:
+```shell
+python -m pytest --cov=arggo
+```
 
 ## Contributing
 

--- a/arggo/cli/__init__.py
+++ b/arggo/cli/__init__.py
@@ -1,0 +1,1 @@
+from .main import main

--- a/arggo/cli/cli.py
+++ b/arggo/cli/cli.py
@@ -1,0 +1,90 @@
+import json
+import os
+import subprocess
+from os.path import join
+
+import jinja2
+from interactive_argparse import PyInquirerPrompter, Question, QuestionKind
+
+from arggo.experiment import FinishedExperiment
+
+_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def write_new_file(template_file: str, output_file: str, *args, **kwargs):
+    template_loader = jinja2.FileSystemLoader(
+        searchpath=os.path.join(_DIR, "../templates")
+    )
+    template_env = jinja2.Environment(loader=template_loader)
+    template = template_env.get_template(template_file)
+    with open(output_file, "w") as f:
+        f.write(template.render(*args, tag="arggo", **kwargs))
+
+
+def experiment_create(name: str):
+    template_file = "experiment_create.jinja"
+    output_file = f"{name}.py"
+    write_new_file(template_file, output_file, experiment_name=name)
+
+
+def experiment_run(name: str):
+    # Delegate the actual prompting to the target script's own
+    # `InteractiveArgumentParser` (via arggo's `--arggo_interactive` meta-flag)
+    # instead of re-building questions for it here.
+    executable = "python"
+    command = f"{name}.py"
+    subprocess.run([executable, command, "--arggo_interactive"])
+
+
+def _validate_parameters_file(file_path: str, experiment_name: str):
+    with open(file_path) as f:
+        parameters = json.load(f)
+        metaparams = dict(parameters["__arggo"])
+        script = metaparams.get("script", None)
+        if script is None:
+            return False
+
+        return script.split("/")[-1].replace(".py", "") == experiment_name.replace(
+            ".py", ""
+        )
+
+
+def _is_experiment_subfolder(path: str, experiment_name: str):
+    parameters_file_path = join(path, "parameters.json")
+    return os.path.isfile(parameters_file_path) and _validate_parameters_file(
+        parameters_file_path, experiment_name
+    )
+
+
+def _lookup_experiments(base_dir: str, experiment_name: str):
+    """
+    A recursive method to look up directories which contain previously run experiments.
+    :param base_dir: The base (root) dir to lookup from
+    :param experiment_name: The experiment name to look for
+    :return:
+    """
+    found_directories = []
+    if _is_experiment_subfolder(base_dir, experiment_name):
+        found_directories.append(base_dir)
+
+    sub_folders_with_paths = [f.path for f in os.scandir(base_dir) if f.is_dir()]
+    for sub_folder in sub_folders_with_paths:
+        found_directories += _lookup_experiments(sub_folder, experiment_name)
+    return found_directories
+
+
+def experiment_reproduce(name: str, base_dir: str):
+    found_experiments = sorted(_lookup_experiments(base_dir, name))
+    if len(found_experiments) == 0:
+        print("No experiments found to reproduce")
+        return
+    question = Question(
+        name="experiment_path",
+        message="Found these experiments. Select one to reproduce:",
+        kind=QuestionKind.SINGLE_CHOICE,
+        choices=found_experiments,
+    )
+    answers = PyInquirerPrompter()([question])
+    experiment_path = answers["experiment_path"]
+    experiment = FinishedExperiment(experiment_path)
+    experiment.reproduce()

--- a/arggo/cli/click_hooks.py
+++ b/arggo/cli/click_hooks.py
@@ -1,0 +1,39 @@
+from .cli import *
+import click
+
+
+@click.group()
+def main():
+    pass
+
+
+@main.group()
+def experiment():
+    pass
+
+
+@experiment.command()
+@click.argument("name", nargs=1)
+def create(name: str):
+    print(f"Creating an experiment named {name}")
+    experiment_create(name)
+
+
+@experiment.command()
+@click.argument("name", nargs=1)
+@click.option(
+    "--logging_dir",
+    prompt="The directory in which to look for experiments to reproduce",
+    type=str,
+    default="logs",
+)
+def reproduce(name: str, logging_dir: str):
+    print(f"Looking for instances of the {name} experiment to reproduce")
+    experiment_reproduce(name, logging_dir)
+
+
+@experiment.command()
+@click.argument("name", nargs=1)
+def run(name: str):
+    print(f"Running experiment {name} interactively...")
+    experiment_run(name)

--- a/arggo/cli/main.py
+++ b/arggo/cli/main.py
@@ -1,0 +1,5 @@
+from arggo.cli.click_hooks import main
+
+
+if __name__ == "__main__":
+    main()

--- a/arggo/core.py
+++ b/arggo/core.py
@@ -4,9 +4,10 @@ import os
 import sys
 from argparse import ArgumentParser, Namespace
 from dataclasses import is_dataclass
-from os.path import join, abspath
+from os.path import join
 from typing import Any, Callable, Optional, get_type_hints, Union, Text, Sequence, List
 
+from .experiment import NewExperiment
 from .integration.conda import CondaPlugin
 from .plugin import Plugin
 
@@ -18,11 +19,12 @@ else:
 from ._internal.global_store import GlobalStore
 from .environment.workdir import Workdir
 from .logger import FileLogger
-from .parser import DataClassArgumentParser, dataclass_to_json
+from .parser import DataClassArgumentParser
 
-_PARAMETERS_FILE_NAME = "parameters.json"
 _OUTPUT_FILE_NAME = "output.log"
-_METADATA_KEY = "__arggo"
+
+
+global_store = GlobalStore()
 
 
 class TaskFunction(Protocol):
@@ -42,11 +44,14 @@ class _MetaHelpAction(argparse.Action):
         parser.exit()
 
 
-def _init_work_directory(logging_dir: str, init_working_dir: bool) -> Workdir:
-    from .environment.workdir import Workdir
+def _init_work_directory(
+    logging_dir: str, tag: str = None, init_working_dir: bool = True
+) -> Workdir:
+    from .environment.workdir import get_workdir
 
-    workdir = Workdir(GlobalStore())
+    workdir = get_workdir()
     if init_working_dir:
+        logging_dir = logging_dir if tag is None else join(logging_dir, tag)
         workdir.initialize(logging_dir)
     else:
         output_dir = join(workdir.workdir(), logging_dir)
@@ -57,25 +62,12 @@ def _init_work_directory(logging_dir: str, init_working_dir: bool) -> Workdir:
 
 def _init_logging_to_file(output_dir: str, output_file_name: str = _OUTPUT_FILE_NAME):
     output_file_path = join(output_dir, output_file_name)
-    file_logger = FileLogger(GlobalStore(), output_file_path)
+    file_logger = FileLogger(global_store, output_file_path)
     file_logger.bind()
 
 
-def _try_discover_parameters_file(path: str):
-    if os.path.isdir(path):
-        file_name = _PARAMETERS_FILE_NAME
-        if os.path.exists(join(path, file_name)):
-            return join(path, file_name)
-        raise FileNotFoundError(
-            f"Could not find a {file_name} file in {path}. Make sure this is a valid directory."
-        )
-    if os.path.exists(path):
-        return path
-    raise FileNotFoundError(f"Parameters file {path} does not exist")
-
-
 def _meta_arguments():
-    meta_parser = argparse.ArgumentParser(add_help=False)
+    meta_parser = ArgumentParser(add_help=False)
 
     meta_parser.add_argument("--arggo_help", action=_MetaHelpAction, nargs=0)
     meta_parser.add_argument(
@@ -84,7 +76,7 @@ def _meta_arguments():
         required=False,
         default=None,
         help=f"Use this argument to reproduce a configuration from a previously saved run. Must be either "
-        f"a directory containing a {_PARAMETERS_FILE_NAME} file, or a path to such a file",
+        f"a directory containing a parameters file, or a path to such a file",
     )
     (meta_args,) = meta_parser.parse_known_args()[:1]
     return meta_args
@@ -99,7 +91,6 @@ def _main_annotation(
     logging_dir="logs",
     init_working_dir=True,
     plugins: List[Plugin] = None,
-    parameters_file_name=_PARAMETERS_FILE_NAME,
 ) -> Callable[[Any], Any]:
     """Decorate a main method with this decorator to enable Arggo
 
@@ -133,55 +124,41 @@ def _main_annotation(
             save_parameters = True
             log_to_file = True
 
-            parser = DataClassArgumentParser(parser_argument_type_hint)
             meta_args = _meta_arguments()
+            parser = global_store.get("parser", None)
+            update_parser = False
+            # TODO Proper caching
+            if not parser:
+                parser = DataClassArgumentParser(parser_argument_type_hint)
+                update_parser = True
 
-            reproduce_from_file = None
-            if meta_args and meta_args.arggo_reproduce is not None:
-                reproduce_from_file = _try_discover_parameters_file(
-                    meta_args.arggo_reproduce
-                )
-                (args,) = parser.parse_json_file(reproduce_from_file)[:1]
+            if update_parser:
+                global_store.put("parser", parser)
+
+                if meta_args and meta_args.arggo_reproduce is not None:
+                    experiment = NewExperiment.from_reproduced(
+                        parser, meta_args.arggo_reproduce
+                    )
+                else:
+                    experiment = NewExperiment.from_arguments(parser)
+                global_store.put("experiment", experiment)
             else:
-                (args,) = parser.parse_args_into_dataclasses(
-                    return_remaining_strings=True
-                )[:1]
+                experiment = global_store.get("experiment")
 
-            workdir = _init_work_directory(logging_dir, init_working_dir)
+            workdir = _init_work_directory(logging_dir, None, init_working_dir)
             output_dir = workdir.workdir()
 
             # Save output
             if log_to_file:
                 _init_logging_to_file(output_dir)
 
-                # output_file_name = "output.err"
-                # output_file_path = join(output_dir, output_file_name)
-                # bind_logger_to_stderr(output_file_path)
-
             # Save parameters
             if save_parameters:
-                # TODO Make configurable
-                parameters_file_path = join(output_dir, parameters_file_name)
-                additional_metadata = dict()
-                if reproduce_from_file is not None:
-                    additional_metadata["reproduced_from"] = abspath(
-                        reproduce_from_file
-                    )
-                additional_metadata["executable"] = sys.executable
-                additional_metadata["command"] = " ".join(sys.argv)
-                for plugin in plugins:
-                    dump = plugin.parameters_dump()
-                    if dump is not None:
-                        additional_metadata[plugin.name] = dump
-
-                with open(parameters_file_path, "w") as f:
-                    f.write(
-                        dataclass_to_json(args, {_METADATA_KEY: additional_metadata})
-                    )
+                experiment.save_json(output_dir, plugins)
 
             new_args_passed = [
                 *args_passed[:parser_argument_index],
-                args,
+                experiment.stripped_parameters,
                 *args_passed[parser_argument_index:],
             ]
             return task_function(*new_args_passed, **kwargs_passed)

--- a/arggo/core.py
+++ b/arggo/core.py
@@ -6,6 +6,9 @@ from argparse import ArgumentParser, Namespace
 from dataclasses import is_dataclass
 from os.path import join
 from typing import Any, Callable, Optional, get_type_hints, Union, Text, Sequence, List
+from rich.console import Console
+
+console = Console()
 
 from .experiment import NewExperiment
 from .integration.conda import CondaPlugin
@@ -20,6 +23,7 @@ from ._internal.global_store import GlobalStore
 from .environment.workdir import Workdir
 from .logger import FileLogger
 from .parser import DataClassArgumentParser
+from interactive_argparse import InteractiveArgumentParser
 
 _OUTPUT_FILE_NAME = "output.log"
 
@@ -70,6 +74,11 @@ def _meta_arguments():
     meta_parser = ArgumentParser(add_help=False)
 
     meta_parser.add_argument("--arggo_help", action=_MetaHelpAction, nargs=0)
+    meta_parser.add_argument(
+        "--arggo_interactive",
+        action="store_true",
+        help="Use this meta-argument to accept program arguments in an interactive mode",
+    )
     meta_parser.add_argument(
         "--arggo_reproduce",
         type=str,
@@ -132,6 +141,12 @@ def _main_annotation(
                 parser = DataClassArgumentParser(parser_argument_type_hint)
                 update_parser = True
 
+                if meta_args and meta_args.arggo_interactive:
+                    console.print(
+                        "[bold cyan] Running with interactive mode [/bold cyan]"
+                    )
+                    parser = InteractiveArgumentParser(parser)
+
             if update_parser:
                 global_store.put("parser", parser)
 
@@ -140,7 +155,15 @@ def _main_annotation(
                         parser, meta_args.arggo_reproduce
                     )
                 else:
-                    experiment = NewExperiment.from_arguments(parser)
+                    # `InteractiveArgumentParser` only prompts when it sees no left-over
+                    # CLI args of its own; arggo's `--arggo_interactive` meta-flag would
+                    # otherwise count as one, so force it to treat the call as bare.
+                    interactive_args = (
+                        [] if meta_args and meta_args.arggo_interactive else None
+                    )
+                    experiment = NewExperiment.from_arguments(
+                        parser, args=interactive_args
+                    )
                 global_store.put("experiment", experiment)
             else:
                 experiment = global_store.get("experiment")

--- a/arggo/experiment/__init__.py
+++ b/arggo/experiment/__init__.py
@@ -1,0 +1,1 @@
+from .experiment import Experiment, FinishedExperiment, NewExperiment

--- a/arggo/experiment/experiment.py
+++ b/arggo/experiment/experiment.py
@@ -81,9 +81,11 @@ class NewExperiment(Experiment):
         return NewExperiment(args, reproduce_from_file)
 
     @classmethod
-    def from_arguments(cls, parser):
-        (args,) = parser.parse_args_into_dataclasses(return_remaining_strings=True)[:1]
-        return NewExperiment(args)
+    def from_arguments(cls, parser, args=None):
+        (parsed_args,) = parser.parse_args_into_dataclasses(
+            args=args, return_remaining_strings=True
+        )[:1]
+        return NewExperiment(parsed_args)
 
 
 def _try_discover_parameters_file(path: str):

--- a/arggo/experiment/experiment.py
+++ b/arggo/experiment/experiment.py
@@ -1,0 +1,135 @@
+import json
+import subprocess
+import sys
+from abc import ABC, abstractmethod
+from argparse import Namespace
+from dataclasses import is_dataclass, asdict
+from os.path import join, abspath, isdir, exists
+from typing import List
+
+from arggo.parser import dataclass_to_json, DataClassType
+from arggo.plugin import Plugin
+
+_PARAMETERS_FILE_NAME = "parameters.json"
+_METADATA_KEY = "__arggo"
+
+
+class Experiment(ABC):
+    @property
+    @abstractmethod
+    def parameters(self):
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def stripped_parameters(self):
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def meta_parameters(self):
+        raise NotImplementedError()
+
+    def to_json(self, plugins: List[Plugin]):
+        meta_params = self.meta_parameters
+        for plugin in plugins:
+            dump = plugin.parameters_dump()
+            if dump is not None:
+                meta_params[plugin.name] = dump
+        return dataclass_to_json(self.stripped_parameters, {_METADATA_KEY: meta_params})
+
+
+class NewExperiment(Experiment):
+    def __init__(self, args: DataClassType, reproduced_from_path=None):
+        if args is None:
+            raise ValueError("args cannot be None")
+        if not is_dataclass(args):
+            raise ValueError(
+                f"args must be a dataclass object, but got {args.__class__.__name__}, "
+                f"which is not a dataclass."
+            )
+        self._args = args
+        self._reproduced_from_path = reproduced_from_path
+
+    @property
+    def parameters(self):
+        return {**asdict(self._args), _METADATA_KEY: self.meta_parameters}
+
+    @property
+    def stripped_parameters(self):
+        return self._args
+
+    @property
+    def meta_parameters(self):
+        additional_metadata = dict()
+        if self._reproduced_from_path is not None:
+            additional_metadata["reproduced_from"] = abspath(self._reproduced_from_path)
+        additional_metadata["executable"] = sys.executable
+        additional_metadata["command"] = " ".join(sys.argv)
+        additional_metadata["script"] = sys.argv[0]
+        return additional_metadata
+
+    def save_json(self, base_dir: str, plugins: List[Plugin]):
+        parameters_file_path = join(base_dir, _PARAMETERS_FILE_NAME)
+        with open(parameters_file_path, "w") as f:
+            f.write(self.to_json(plugins))
+
+    @classmethod
+    def from_reproduced(cls, parser, reproduced_from_dir):
+        reproduce_from_file = _try_discover_parameters_file(reproduced_from_dir)
+        (args,) = parser.parse_json_file(reproduce_from_file)[:1]
+        return NewExperiment(args, reproduce_from_file)
+
+    @classmethod
+    def from_arguments(cls, parser):
+        (args,) = parser.parse_args_into_dataclasses(return_remaining_strings=True)[:1]
+        return NewExperiment(args)
+
+
+def _try_discover_parameters_file(path: str):
+    if isdir(path):
+        file_name = _PARAMETERS_FILE_NAME
+        if exists(join(path, file_name)):
+            return join(path, file_name)
+        raise FileNotFoundError(
+            f"Could not find a {file_name} file in {path}. Make sure this is a valid directory."
+        )
+    if exists(path):
+        return path
+    raise FileNotFoundError(f"Parameters file {path} does not exist")
+
+
+class FinishedExperiment(Experiment):
+    def __init__(self, base_dir):
+        if base_dir is None:
+            raise ValueError(
+                "base_dir must not be None, as this must be an existing experiment"
+            )
+        self._base_dir = base_dir
+        self._parameters = None
+
+    def _parameters_file_path(self):
+        return join(self._base_dir, "parameters.json")
+
+    @property
+    def parameters(self):
+        if self._parameters is None:
+            with open(self._parameters_file_path()) as f:
+                self._parameters = json.load(f)
+        return self._parameters
+
+    @property
+    def stripped_parameters(self):
+        p = dict(self.parameters)
+        del p[_METADATA_KEY]
+        return Namespace(**p)
+
+    @property
+    def meta_parameters(self):
+        return self.parameters[_METADATA_KEY]
+
+    def reproduce(self):
+        print(f"Reproducing from {self._base_dir}")
+        executable = self.meta_parameters["executable"]
+        command = self.meta_parameters["script"]
+        subprocess.run([executable, command, "--arggo_reproduce", self._base_dir])

--- a/arggo/logger.py
+++ b/arggo/logger.py
@@ -1,6 +1,25 @@
+import logging
 import sys
 
 from arggo._internal.global_store import GlobalStore
+
+
+class WrapperStream:
+    def __init__(self, stream, log):
+        self.stream = stream
+        self.log = log
+
+    # Proxy
+    def __getattr__(self, attr):
+        return getattr(self.stream, attr)
+
+    def write(self, message):
+        if self.stream is not None:
+            self.stream.write(message)
+        self.log.write(message)
+
+    def flush(self):
+        pass
 
 
 class FileLogger:
@@ -15,21 +34,14 @@ class FileLogger:
     def bind(
         self,
     ):
-        self.terminal = sys.stdout
         if not self.gs.get(FileLogger._KEY_BOUND, False):
-            sys.stdout = self
+            self.terminal = sys.stdout
+            sys.stdout = WrapperStream(sys.stdout, self.log)
+            # sys.stderr = WrapperStream(sys.stderr, self.log)
+            for handler in logging.root.handlers:
+                if isinstance(handler, logging.StreamHandler):
+                    handler.stream = WrapperStream(handler.stream, self.log)
             self.gs.put(FileLogger._KEY_BOUND, True)
-
-    def write(self, message):
-        if self.terminal is not None:
-            self.terminal.write(message)
-        self.log.write(message)
-
-    def flush(self):
-        # this flush method is needed for python 3 compatibility.
-        # this handles the flush command by doing nothing.
-        # you might want to specify some extra behavior here.
-        pass
 
     def original_stdout(self):
         return self.terminal

--- a/arggo/parser.py
+++ b/arggo/parser.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import dataclasses
 import json
 import re

--- a/arggo/templates/experiment_create.jinja
+++ b/arggo/templates/experiment_create.jinja
@@ -1,0 +1,28 @@
+#
+# An experiment file created by {{ tag }}
+# Run using python {{ experiment_name }}.py
+#
+from dataclasses import dataclass
+import logging
+import arggo
+from arggo.dataclass_utils import parser_field
+
+
+experiment_name = "{{ experiment_name }}"
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(experiment_name)
+
+
+@dataclass
+class Arguments:
+    number: int = 0
+
+
+@arggo.consume
+def main(args: Arguments):
+    logger.info(f"Starting Experiment {experiment_name}")
+    logger.info(f"number = {args.number}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/assets/coverage.svg
+++ b/docs/assets/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="#dfb317" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">80%</text>
-        <text x="80" y="14">80%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">70%</text>
+        <text x="80" y="14">70%</text>
     </g>
 </svg>

--- a/examples/simple_configure.py
+++ b/examples/simple_configure.py
@@ -1,9 +1,4 @@
-import os
 from dataclasses import dataclass
-import sys
-
-sys.path.append(os.getcwd())
-sys.path.append("../")
 import arggo
 from arggo.dataclass_utils import parser_field
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ coverage-badge==1.0.1
 twine
 pre-commit
 setuptools
+wandb==0.10.33

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click==8.0.1
 Jinja2==3.0.1
 InteractiveArgparse
+rich==10.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+click==8.0.1
+Jinja2==3.0.1
+InteractiveArgparse

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+import setuptools
+
+setuptools.setup(
+    name="arggo",
+    version="0.3.0",
+    author="Miki Mendelson-Mints",
+    author_email="mikimn1999@gmail.com",
+    description="The no-brainer package for setting up python experiments.",
+    url="https://github.com/mikimn/arggo",
+    packages=setuptools.find_packages(),
+    entry_points={
+        "console_scripts": ["arggo-cli=arggo.cli:main"],
+    },
+    install_requires=[
+        "setuptools",
+    ],
+    include_package_data=True,
+    python_requires=">=3.7",
+)

--- a/tests/test_wandb.py
+++ b/tests/test_wandb.py
@@ -1,0 +1,7 @@
+# import wandb
+#
+#
+# class TestWandb:
+#     def test_wandb_workdir(self):
+#         wandb.init(name='test_wandb_workdir', project='arggo-test')
+#         raise NotImplementedError()


### PR DESCRIPTION
## Summary

- Extracts run-parameter persistence/reproduction into a new `Experiment`/`NewExperiment`/`FinishedExperiment` abstraction (`arggo/experiment/`), and fixes a bug where calling a second `@arggo.consume`/`@arggo.configure`-decorated function (or looping over the same one, as in the README's `greet_user` example) in the same process crashed with `UnboundLocalError` because only the parser — not the experiment — was cached.
- Adds `arggo-cli`, a click-based CLI for `experiment create/reproduce/run`.
- Adds `--arggo_interactive` support in `core.py`, backed by the `InteractiveArgparse` library, so scripts can be filled out via an interactive prompt instead of the command line.
- Mirrors `logging` module output (not just `sys.stdout` writes) into each run's log file.
- Documents all of the above in the README, and adds a `CLAUDE.md` guide for future AI-assisted work in this repo.
- Misc: adds a wandb dev dependency + placeholder test, ignores `temp/`, drops manual `sys.path` hacks from an example, reformats `parser.py`, and pins `click` for the `black` pre-commit hook (which was broken on any commit).

## Commits

Organized as one logical change per commit — see `git log master..feature/experiment-cli-and-interactive-mode` for the full list and messages.

## Test plan

- [x] `python -m pytest --cov=arggo` — 27 passed, 1 skipped
- [x] `flake8 . --count --select=E9,F63,F7,F82` — clean
- [x] Manually verified `--arggo_interactive` end-to-end with a stubbed prompter
- [x] Manually verified the README's `greet_user` loop example (previously crashed on the 2nd iteration)