### PR TITLE
Fix mapped_field's mapper being silently ignored

### DIFF
--- a/arggo/parser.py
+++ b/arggo/parser.py
@@ -199,7 +199,11 @@ class DataClassArgumentParser(ArgumentParser):
             elif isinstance(field.type, type) and issubclass(field.type, Enum):
                 kwargs = _handle_kwargs_enum(field, kwargs)
             else:
-                kwargs["type"] = field.type
+                # A mapped_field() may have already supplied its mapper as
+                # metadata["type"]; only fall back to the raw field type
+                # when no such override is present.
+                if "type" not in kwargs:
+                    kwargs["type"] = field.type
                 if field.default is not dataclasses.MISSING:
                     kwargs["default"] = field.default
                 elif field.default_factory is not dataclasses.MISSING:

--- a/docs/assets/coverage.svg
+++ b/docs/assets/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">70%</text>
-        <text x="80" y="14">70%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
+        <text x="80" y="14">71%</text>
     </g>
 </svg>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -21,6 +21,7 @@ from typing import List, Optional
 
 import pytest
 
+from arggo.dataclass_utils import mapped_field
 from arggo.parser import DataClassArgumentParser
 from arggo.parser import string_to_bool
 
@@ -88,6 +89,25 @@ class RequiredExample:
 
     # def __post_init__(self):
     #     self.required_enum = BasicEnum(self.required_enum)
+
+
+class Point:
+    def __init__(self, x: int, y: int):
+        self.x = x
+        self.y = y
+
+    def __eq__(self, other):
+        return isinstance(other, Point) and self.x == other.x and self.y == other.y
+
+
+def parse_point(s: str) -> Point:
+    x, y = s.split(",")
+    return Point(int(x), int(y))
+
+
+@dataclass
+class MappedExample:
+    point: Point = mapped_field(mapper=parse_point, default="0,0")
 
 
 class DataClassArgumentParserTest(unittest.TestCase):
@@ -240,6 +260,18 @@ class DataClassArgumentParserTest(unittest.TestCase):
             "--required_enum", type=str, choices=["titi", "toto"], required=True
         )
         self.argparsersEqual(parser, expected)
+
+    def test_with_mapped_field(self):
+        parser = DataClassArgumentParser(MappedExample)
+
+        (example,) = parser.parse_args_into_dataclasses(["--point", "1,2"])
+        self.assertEqual(example.point, Point(1, 2))
+
+        # A string default is run through the mapper too, since argparse
+        # applies `type=` to string defaults the same way it does to
+        # values actually supplied on the command line.
+        (example,) = parser.parse_args_into_dataclasses([])
+        self.assertEqual(example.point, Point(0, 0))
 
     def test_parse_dict(self):
         parser = DataClassArgumentParser(BasicExample)


### PR DESCRIPTION
## Summary

- `DataClassArgumentParser._add_dataclass_arguments`'s generic fallback branch unconditionally did `kwargs["type"] = field.type`, clobbering the mapper function that `mapped_field()` stashes in `field.metadata["type"]`. In practice, argparse was calling `field.type(raw_value)` directly instead of the user-supplied mapper — it only *looked* correct when the annotated type happened to be a single-argument string constructor.
- Fix: only fall back to `field.type` when `metadata` didn't already supply a `type` (i.e. a mapper from `mapped_field`).
- Added `tests/test_parser.py::test_with_mapped_field`, which fails against the old code (the mapper is never invoked) and passes with the fix.

Fixes #6

## Test plan

- [x] `python -m pytest --cov=arggo` — 28 passed, 1 skipped
- [x] `flake8 . --count --select=E9,F63,F7,F82` — clean
- [x] Manually confirmed the mapper is now actually called (previously silent)