### PR TITLE
Raise ArggoReservedError on reserved dataclass field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ To view all possible meta-arguments, run your script with the `--arggo_help` fla
 python main.py --arggo_help
 ```
 
+These names are reserved by Arggo and cannot be used as dataclass field names:
+
+* `arggo_help`
+* `arggo_interactive`
+* `arggo_reproduce`
+
+If a field collides with one of these, Arggo raises `ArggoReservedError`. Rename the field, or opt out with
+`@arggo.configure(override_reserved_arguments=True)` if you're sure the collision is intentional.
+
 #### Interactive Runs
 
 You can provide arguments to a program interactively by supplying the `--arggo_interactive` flag:

--- a/arggo/__init__.py
+++ b/arggo/__init__.py
@@ -1,1 +1,2 @@
 from .core import consume, configure
+from .exceptions import ArggoReservedError

--- a/arggo/core.py
+++ b/arggo/core.py
@@ -3,7 +3,7 @@ import functools
 import os
 import sys
 from argparse import ArgumentParser, Namespace
-from dataclasses import is_dataclass
+from dataclasses import fields, is_dataclass
 from os.path import join
 from typing import Any, Callable, Optional, get_type_hints, Union, Text, Sequence, List
 from rich.console import Console
@@ -11,6 +11,7 @@ from rich.console import Console
 console = Console()
 
 from .experiment import NewExperiment
+from .exceptions import ArggoReservedError
 from .integration.conda import CondaPlugin
 from .plugin import Plugin
 
@@ -70,9 +71,10 @@ def _init_logging_to_file(output_dir: str, output_file_name: str = _OUTPUT_FILE_
     file_logger.bind()
 
 
-def _meta_arguments():
-    meta_parser = ArgumentParser(add_help=False)
+_RESERVED_ARGUMENTS_URL = "https://github.com/mikimn/arggo#meta-arguments"
 
+
+def _add_meta_arguments(meta_parser: ArgumentParser) -> None:
     meta_parser.add_argument("--arggo_help", action=_MetaHelpAction, nargs=0)
     meta_parser.add_argument(
         "--arggo_interactive",
@@ -87,8 +89,32 @@ def _meta_arguments():
         help=f"Use this argument to reproduce a configuration from a previously saved run. Must be either "
         f"a directory containing a parameters file, or a path to such a file",
     )
+
+
+def _meta_arguments():
+    meta_parser = ArgumentParser(add_help=False)
+    _add_meta_arguments(meta_parser)
     (meta_args,) = meta_parser.parse_known_args()[:1]
     return meta_args
+
+
+def _reserved_argument_names() -> Sequence[str]:
+    meta_parser = ArgumentParser(add_help=False)
+    _add_meta_arguments(meta_parser)
+    return [action.dest for action in meta_parser._actions if action.dest != "help"]
+
+
+def _check_reserved_arguments(dtype, override_reserved_arguments: bool) -> None:
+    if override_reserved_arguments:
+        return
+    reserved_names = _reserved_argument_names()
+    for f in fields(dtype):
+        if f.name in reserved_names:
+            raise ArggoReservedError(
+                f"Error: Argument --{f.name} is reserved by Arggo. Please either rename it or set "
+                f"@arggo.configure(override_reserved_arguments=True) when initializing. For a list of "
+                f"reserved argument names, see {_RESERVED_ARGUMENTS_URL}"
+            )
 
 
 def _load_default_plugins():
@@ -100,11 +126,15 @@ def _main_annotation(
     logging_dir="logs",
     init_working_dir=True,
     plugins: List[Plugin] = None,
+    override_reserved_arguments: bool = False,
 ) -> Callable[[Any], Any]:
     """Decorate a main method with this decorator to enable Arggo
 
     :param parser_argument_index: The index of the argument which will be our dataclass (default: 0). This is useful
     when the main method receives more than one argument in a non-standard ordering.
+    :param override_reserved_arguments: By default, a dataclass field whose name collides with one of Arggo's
+    reserved meta-argument names (e.g. arggo_interactive) raises ArggoReservedError. Set this to True to allow
+    the collision instead.
     """
     if plugins is None:
         plugins = []
@@ -138,6 +168,9 @@ def _main_annotation(
             update_parser = False
             # TODO Proper caching
             if not parser:
+                _check_reserved_arguments(
+                    parser_argument_type_hint, override_reserved_arguments
+                )
                 parser = DataClassArgumentParser(parser_argument_type_hint)
                 update_parser = True
 

--- a/arggo/core.py
+++ b/arggo/core.py
@@ -71,9 +71,6 @@ def _init_logging_to_file(output_dir: str, output_file_name: str = _OUTPUT_FILE_
     file_logger.bind()
 
 
-_RESERVED_ARGUMENTS_URL = "https://github.com/mikimn/arggo#meta-arguments"
-
-
 def _add_meta_arguments(meta_parser: ArgumentParser) -> None:
     meta_parser.add_argument("--arggo_help", action=_MetaHelpAction, nargs=0)
     meta_parser.add_argument(
@@ -91,17 +88,21 @@ def _add_meta_arguments(meta_parser: ArgumentParser) -> None:
     )
 
 
-def _meta_arguments():
+def _build_meta_parser() -> ArgumentParser:
     meta_parser = ArgumentParser(add_help=False)
     _add_meta_arguments(meta_parser)
-    (meta_args,) = meta_parser.parse_known_args()[:1]
+    return meta_parser
+
+
+def _meta_arguments():
+    (meta_args,) = _build_meta_parser().parse_known_args()[:1]
     return meta_args
 
 
 def _reserved_argument_names() -> Sequence[str]:
-    meta_parser = ArgumentParser(add_help=False)
-    _add_meta_arguments(meta_parser)
-    return [action.dest for action in meta_parser._actions if action.dest != "help"]
+    return [
+        action.dest for action in _build_meta_parser()._actions if action.dest != "help"
+    ]
 
 
 def _check_reserved_arguments(dtype, override_reserved_arguments: bool) -> None:
@@ -112,8 +113,8 @@ def _check_reserved_arguments(dtype, override_reserved_arguments: bool) -> None:
         if f.name in reserved_names:
             raise ArggoReservedError(
                 f"Error: Argument --{f.name} is reserved by Arggo. Please either rename it or set "
-                f"@arggo.configure(override_reserved_arguments=True) when initializing. For a list of "
-                f"reserved argument names, see {_RESERVED_ARGUMENTS_URL}"
+                f"@arggo.configure(override_reserved_arguments=True) when initializing. "
+                f"Reserved argument names: {', '.join(sorted(reserved_names))}"
             )
 
 

--- a/arggo/exceptions.py
+++ b/arggo/exceptions.py
@@ -1,0 +1,3 @@
+class ArggoReservedError(Exception):
+    """Raised when a user-defined dataclass field collides with an argument name
+    reserved by Arggo for its own meta-arguments (e.g. --arggo_interactive)."""

--- a/tests/test_reserved_arguments.py
+++ b/tests/test_reserved_arguments.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, field
+
+import pytest
+
+from arggo.core import _check_reserved_arguments
+from arggo.exceptions import ArggoReservedError
+
+
+@dataclass
+class ReservedArguments:
+    arggo_interactive: bool = field(default=False)
+
+
+@dataclass
+class UnreservedArguments:
+    name: str = field(default="World")
+
+
+class TestCheckReservedArguments:
+    def test_raises_on_reserved_field_name(self):
+        with pytest.raises(ArggoReservedError):
+            _check_reserved_arguments(
+                ReservedArguments, override_reserved_arguments=False
+            )
+
+    def test_override_bypasses_check(self):
+        _check_reserved_arguments(ReservedArguments, override_reserved_arguments=True)
+
+    def test_unreserved_field_name_passes(self):
+        _check_reserved_arguments(
+            UnreservedArguments, override_reserved_arguments=False
+        )


### PR DESCRIPTION
## Summary

- Confirmed live bug: a user dataclass field named e.g. `arggo_interactive` collides with arggo's own meta-flag of the same name. Passing `--arggo_interactive` on the CLI gets consumed entirely by arggo's meta-argument parser (silently enabling interactive mode) instead of setting the user's field — with no error, just confusing/wrong behavior (and a crash outside a TTY).
- Adds `ArggoReservedError` (`arggo/exceptions.py`, exported from `arggo/__init__.py`) and a `_check_reserved_arguments` check that runs once per fresh parser build, raising with the exact message format proposed in the issue when a field name collides with a reserved meta-argument name.
- Reserved names (`arggo_help`, `arggo_interactive`, `arggo_reproduce`) are now derived from a shared `_add_meta_arguments()` helper instead of being duplicated, so the check can't silently drift out of sync with the actual meta-parser.
- Opt-out via `@arggo.configure(override_reserved_arguments=True)`, per the issue.
- Documented the reserved names and the opt-out in the README's Meta-arguments section (linked from the error message).

Fixes #5

## Test plan

- [x] `python -m pytest --cov=arggo` — 31 passed, 1 skipped
- [x] `flake8 . --count --select=E9,F63,F7,F82` — clean
- [x] Manually reproduced the original collision (`--arggo_interactive` field) and confirmed it now raises `ArggoReservedError` instead of silently misbehaving
- [x] Manually confirmed `override_reserved_arguments=True` bypasses the check