### PR TITLE
Raise ArggoAlreadyConfiguredError on multiple distinct entry points

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,6 +35,7 @@ jobs:
           python -m pytest --cov=arggo
           coverage-badge -o docs/assets/coverage.svg -f
       - name: Update Coverage
+        if: matrix.python-version == '3.10'
         uses: EndBug/add-and-commit@v7 # You can change this to use a specific version
         with:
           # The arguments for the `git add` command (see the paragraph below for more info)

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Greetings for the 3rd time, John!
 
 The `consume` and `configure()` decorators work for any function, and guarantee that the same objects are provided each time.
 
-**Note**: Arggo relies on the first `configure()` it uses to load everything, initialize the work directory and
-configure parametes. Future versions will make `consume` automatically find
-the appropriate type parameter to inject the arguments object into, and consequently
-`configure()` will throw an error when used more than once.
+**Note**: Arggo relies on the first `consume`/`configure()`-decorated call in a process to load everything and
+initialize the work directory; calling that same decorated function again (e.g. in a loop, as above) reuses it.
+Calling a *different* `consume`/`configure()`-decorated entry point in the same process instead raises
+`ArggoAlreadyConfiguredError`, since only one entry point's configuration can be in effect per process.
 
 ### Meta-arguments
 

--- a/arggo/__init__.py
+++ b/arggo/__init__.py
@@ -1,2 +1,2 @@
 from .core import consume, configure
-from .exceptions import ArggoReservedError
+from .exceptions import ArggoAlreadyConfiguredError, ArggoReservedError

--- a/arggo/core.py
+++ b/arggo/core.py
@@ -11,7 +11,7 @@ from rich.console import Console
 console = Console()
 
 from .experiment import NewExperiment
-from .exceptions import ArggoReservedError
+from .exceptions import ArggoAlreadyConfiguredError, ArggoReservedError
 from .integration.conda import CondaPlugin
 from .plugin import Plugin
 
@@ -118,6 +118,17 @@ def _check_reserved_arguments(dtype, override_reserved_arguments: bool) -> None:
             )
 
 
+def _check_not_already_configured(task_function: TaskFunction) -> None:
+    configured_by = global_store.get("configured_by", None)
+    if configured_by is not None and configured_by is not task_function:
+        raise ArggoAlreadyConfiguredError(
+            f"Error: Arggo has already been configured by a different entry point "
+            f"({configured_by.__qualname__}) in this process. consume()/configure() "
+            f"perform a one-time, process-wide setup: call the same decorated function "
+            f"repeatedly (e.g. in a loop) rather than decorating more than one entry point."
+        )
+
+
 def _load_default_plugins():
     return [CondaPlugin()]
 
@@ -164,6 +175,8 @@ def _main_annotation(
             save_parameters = True
             log_to_file = True
 
+            _check_not_already_configured(task_function)
+
             meta_args = _meta_arguments()
             parser = global_store.get("parser", None)
             update_parser = False
@@ -183,6 +196,7 @@ def _main_annotation(
 
             if update_parser:
                 global_store.put("parser", parser)
+                global_store.put("configured_by", task_function)
 
                 if meta_args and meta_args.arggo_reproduce is not None:
                     experiment = NewExperiment.from_reproduced(

--- a/arggo/exceptions.py
+++ b/arggo/exceptions.py
@@ -1,3 +1,8 @@
 class ArggoReservedError(Exception):
     """Raised when a user-defined dataclass field collides with an argument name
     reserved by Arggo for its own meta-arguments (e.g. --arggo_interactive)."""
+
+
+class ArggoAlreadyConfiguredError(Exception):
+    """Raised when a second, distinct consume/configure-decorated entry point
+    is invoked in a process that has already been configured by another one."""

--- a/docs/assets/coverage.svg
+++ b/docs/assets/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">71%</text>
-        <text x="80" y="14">71%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">73%</text>
+        <text x="80" y="14">73%</text>
     </g>
 </svg>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from arggo._internal.global_store import GlobalStore
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_store():
+    """Each test should behave like its own process: arggo's process-wide
+    GlobalStore (parser/experiment cache, workdir state) must not leak
+    between tests."""
+    GlobalStore().clear()
+    yield
+    GlobalStore().clear()

--- a/tests/test_arggo.py
+++ b/tests/test_arggo.py
@@ -5,6 +5,7 @@ import pytest
 
 import arggo
 from arggo.dataclass_utils import parser_field
+from arggo.exceptions import ArggoAlreadyConfiguredError
 
 
 @dataclass
@@ -80,3 +81,26 @@ class TestConfigureAnnotation:
 
         # assert decorated("World!") == "Hello, World!"
         # sys.argv += old_sys_argv
+
+
+class TestMultipleConfigureCalls:
+    def test_same_function_called_repeatedly_does_not_raise(self):
+        @arggo.consume
+        def decorated(args: SimpleArguments):
+            return args.just_a_string
+
+        for _ in range(3):
+            assert decorated() == "Hello"
+
+    def test_second_distinct_entry_point_raises(self):
+        @arggo.consume
+        def first(args: SimpleArguments):
+            return args.just_a_string
+
+        @arggo.consume
+        def second(args: SimpleArguments):
+            return args.just_a_string
+
+        first()
+        with pytest.raises(ArggoAlreadyConfiguredError):
+            second()


### PR DESCRIPTION
## Summary

- `consume()`/`configure()` cache their built parser/experiment/workdir in a process-wide `GlobalStore`, keyed only by "has anything been cached yet" — not by *which* decorated function built it. So a second, distinct `consume`/`configure`-decorated entry point invoked in the same process silently reused the first one's parser/experiment (wrong dataclass type, wrong `logging_dir`, etc.) instead of failing loudly.
- Track the `task_function` that performed the first configuration; raise `ArggoAlreadyConfiguredError` if a *different* one attempts to configure again, while still allowing the *same* decorated function to be called repeatedly (the README's `greet_user` loop example).
- **Prerequisite fix**: added `tests/conftest.py` with an autouse fixture that resets `GlobalStore()` between tests. Without it, correctness of existing tests (e.g. `test_workdir.py::test_workdir_is_same_if_no_init`) depended on incidental cleanup from an unrelated test file (`test_global_store.py`'s `setup_method` wiping the whole store) happening to run first — fragile and order-dependent, and it broke outright once this PR's check started exercising multiple distinct entry points across tests in the same process.
- Documented the new behavior in the README, replacing the old "future versions will..." note that predicted exactly this.

Fixes #11

## Test plan

- [x] `python -m pytest --cov=arggo` — 33 passed, 1 skipped
- [x] `flake8 . --count --select=E9,F63,F7,F82` — clean
- [x] Confirmed test order-independence: ran various file-order combinations directly (previously `test_arggo.py` + `test_workdir.py` together would fail without the conftest fix)
- [x] Manually confirmed two distinct decorated entry points raise `ArggoAlreadyConfiguredError`
- [x] Manually confirmed the same decorated function called repeatedly (loop) still works