### PR TITLE
Support Hydra-style key=value parameter syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ initialize the work directory; calling that same decorated function again (e.g. 
 Calling a *different* `consume`/`configure()`-decorated entry point in the same process instead raises
 `ArggoAlreadyConfiguredError`, since only one entry point's configuration can be in effect per process.
 
+### Parameter Styles
+
+Arguments can be passed either argparse-style (`--name value`, or `--name=value`) or Hydra-style (`name=value`), and
+the two can be freely mixed on the same command line:
+```shell
+python main.py --name John should_greet=true
+```
+A bare `key=value` token is only treated as Hydra-style if it doesn't already start with `-`, so `--name=John` keeps
+its usual argparse meaning.
+
 ### Meta-arguments
 
 Arggo attaches meta-arguments to each script, allowing for some extra functionality.

--- a/arggo/parser.py
+++ b/arggo/parser.py
@@ -45,6 +45,26 @@ def string_to_bool(v):
         )
 
 
+_HYDRA_STYLE_KEY_PATTERN = re.compile(r"^[A-Za-z_][\w\-]*$")
+
+
+def _convert_hydra_style_args(args: List[str]) -> List[str]:
+    """Rewrite bare Hydra-style `key=value` tokens into argparse-style
+    `--key value` pairs, so both styles can be used (and mixed) on the same
+    command line. Tokens that already start with `-` (including argparse's
+    own `--key=value` form) are left untouched.
+    """
+    converted = []
+    for arg in args:
+        key, sep, value = arg.partition("=")
+        if sep and not arg.startswith("-") and _HYDRA_STYLE_KEY_PATTERN.match(key):
+            converted.append(f"--{key}")
+            converted.append(value)
+        else:
+            converted.append(arg)
+    return converted
+
+
 def _handle_kwargs_bool(field, kwargs):
     kwargs["type"] = string_to_bool
     if field.type is bool or (
@@ -253,6 +273,9 @@ class DataClassArgumentParser(ArgumentParser):
                 args = fargs + args if args is not None else fargs + sys.argv[1:]
                 # in case of duplicate arguments the first one has precedence
                 # so we append rather than prepend.
+        if args is None:
+            args = sys.argv[1:]
+        args = _convert_hydra_style_args(args)
         namespace, remaining_args = self.parse_known_args(args=args)
         outputs = []
         for dtype in self.dataclass_types:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -292,3 +292,33 @@ class DataClassArgumentParserTest(unittest.TestCase):
         # parser = DataClassArgumentParser(TrainingArguments)
         # self.assertIsNotNone(parser)
         raise NotImplementedError()
+
+
+class TestHydraStyleArgs(unittest.TestCase):
+    def test_hydra_style_args(self):
+        parser = DataClassArgumentParser(BasicExample)
+        (example,) = parser.parse_args_into_dataclasses(
+            ["foo=12", "bar=3.14", "baz=42", "flag=true"]
+        )
+        self.assertEqual(example, BasicExample(foo=12, bar=3.14, baz="42", flag=True))
+
+    def test_hydra_and_argparse_styles_can_be_mixed(self):
+        parser = DataClassArgumentParser(BasicExample)
+        (example,) = parser.parse_args_into_dataclasses(
+            ["--foo", "12", "bar=3.14", "--baz", "42", "flag=true"]
+        )
+        self.assertEqual(example, BasicExample(foo=12, bar=3.14, baz="42", flag=True))
+
+    def test_hydra_style_value_may_contain_equals_sign(self):
+        parser = DataClassArgumentParser(BasicExample)
+        (example,) = parser.parse_args_into_dataclasses(
+            ["foo=1", "bar=1.0", "baz=a=b=c", "flag=false"]
+        )
+        self.assertEqual(example.baz, "a=b=c")
+
+    def test_argparse_equals_form_is_left_untouched(self):
+        parser = DataClassArgumentParser(BasicExample)
+        (example,) = parser.parse_args_into_dataclasses(
+            ["--foo=1", "--bar=1.0", "--baz=hello", "--flag=true"]
+        )
+        self.assertEqual(example, BasicExample(foo=1, bar=1.0, baz="hello", flag=True))


### PR DESCRIPTION
## Summary

Stacked on #16 (this PR's diff is just the new commit on top of it; will retarget to `master` once #15/#16 merge).

- Adds `_convert_hydra_style_args()` in `arggo/parser.py`, which rewrites bare `key=value` tokens (no leading dash) into argparse-style `--key value` pairs before parsing. Scripts can now be invoked either argparse-style (`--name value`, `--name=value`) or Hydra-style (`name=value`), freely mixed on the same command line.
- Tokens already starting with `-` (including argparse's own native `--key=value` form) are left completely untouched.
- Additive and backward compatible: a bare `key=value` token was previously just silently dropped as an unrecognized positional argument (the generated parser has no positional arguments of its own), so no existing invocation's meaning changes.
- Scoped to the concretely-specified part of #9 (Hydra-style `key=value`). The issue also mentions `-p value` short-flag support as an existing-argparse-style example, but arggo doesn't currently support short flags at all — that'd be a separate, larger feature (per-field short-name assignment, conflict resolution) and isn't addressed here.

Fixes #9

## Test plan

- [x] `python -m pytest --cov=arggo` — 46 passed, 1 skipped
- [x] `flake8 . --count --select=E9,F63,F7,F82` — clean
- [x] New tests cover: pure Hydra-style, mixed Hydra+argparse style, a Hydra-style value containing `=`, and confirming argparse's native `--key=value` form is untouched