### PR TITLE
Add release pipeline: version bump, GitHub release, PyPI publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,14 +3,22 @@ name: Upload Python Package
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build and publish (e.g. v0.1.0) - for recovering a release that didn't publish"
+        required: true
+        type: string
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, without a leading 'v' (e.g. 1.2.3)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate version format
+        run: |
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+|rc[0-9]+)?$ ]]; then
+            echo "::error::'${{ inputs.version }}' doesn't look like a valid version (expected e.g. 1.2.3 or 1.2.3rc1)"
+            exit 1
+          fi
+          if git rev-parse "v${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag v${{ inputs.version }} already exists"
+            exit 1
+          fi
+          current_version=$(sed -n "s/.*version=\"\(.*\)\".*/\1/p" setup.py)
+          if [ "${{ inputs.version }}" = "$current_version" ]; then
+            echo "::error::setup.py is already at version $current_version - nothing to bump. Pick a new version."
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Lint
+        run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+
+      - name: Test
+        run: python -m pytest --cov=arggo
+
+      - name: Bump version in setup.py and setup.cfg
+        run: |
+          sed -i "s/version=\"[^\"]*\"/version=\"${{ inputs.version }}\"/" setup.py
+          sed -i "s/^version = .*/version = ${{ inputs.version }}/" setup.cfg
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "[RELEASE] Bump version to ${{ inputs.version }}"
+
+      - name: Tag
+        run: git tag "v${{ inputs.version }}"
+
+      - name: Push commit and tag
+        run: git push origin HEAD:${{ github.ref_name }} "v${{ inputs.version }}"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "v${{ inputs.version }}" --title "v${{ inputs.version }}" --generate-notes
+
+      # Publishing here directly, rather than relying on python-publish.yml's
+      # `on: release: created` trigger, because GitHub Actions does not let
+      # a workflow run authenticated as the default GITHUB_TOKEN (as the
+      # release creation above is) trigger other workflows - that trigger
+      # only fires for releases a human creates by hand, e.g. via the web UI.
+      - name: Build package
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: twine upload dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 # replace with your username:
 name = arggo
-version = 0.0.3
+version = 0.3.0
 author = Miki Mendelson-Mints
 author_email = mikimn1999@gmail.com
 description = The no-brainer package for setting up python experiments


### PR DESCRIPTION
## Summary

Mirrors the release/publish pipeline from [mikimn/InteractiveArgparse](https://github.com/mikimn/InteractiveArgparse).

- **New `.github/workflows/release.yml`** (`workflow_dispatch`, takes a `version` input): validates the version format and that it's actually new (not already released or already the current `setup.py` version), runs lint + tests, bumps the version in `setup.py` and `setup.cfg`, commits and tags it (`vX.Y.Z`), creates a GitHub release with auto-generated notes, then builds and publishes to PyPI directly in the same job.
  - Publishing happens directly in this job rather than relying on `python-publish.yml`'s `release: created` trigger, because a workflow run authenticated as the default `GITHUB_TOKEN` (as the release-creation step is) can't trigger other workflows — that trigger only fires for releases a human creates by hand via the UI.
- **Updated the existing `python-publish.yml`** (previously only triggered by a human creating a release via the GitHub UI) to also accept a `workflow_dispatch` with an existing tag, as a manual recovery path if `release.yml`'s own publish step ever fails after the release is already created. Bumped `actions/checkout`/`actions/setup-python` to v4/v5 to match (was pinned to v2, which is deprecated).
- **Fixed a pre-existing bug found along the way**: `setup.py` calls `setuptools.setup(version="0.3.0", ...)` explicitly, which is what's actually used (verified via `python setup.py --version` and a real `python -m build`) — but `setup.cfg`'s own `version = 0.0.3` under `[metadata]` is dead, unused config that had drifted out of sync. Synced it so the release workflow has one correct starting point to bump from.

**Requires a `PYPI_TOKEN` repository secret** (referenced by both workflows) to actually publish. The pre-existing `python-publish.yml` already referenced this secret, so it's likely already configured — I did not (and cannot) verify or set this myself.

I have not triggered `release.yml` myself; that's left for you to run deliberately once this is merged.

## Test plan

- [x] `python -m pytest --cov=arggo` — 46 passed, 1 skipped
- [x] `flake8 . --count --select=E9,F63,F7,F82` — clean
- [x] YAML-validated both workflow files
- [x] Locally verified the exact `sed` commands used to bump `setup.py`/`setup.cfg` against the real files
- [x] Locally ran `python -m build` end-to-end to confirm the package actually builds (produces `arggo-0.3.0.tar.gz` / `.whl`)
- [ ] Not yet run: the actual `release.yml` workflow (requires a real version bump + `PYPI_TOKEN` + publishing a real release — deliberately left for you to trigger)